### PR TITLE
Remove email form AUTHORS list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,2 @@
-Joel Poudroux <joel REMOVEIT at hippersoft dot fr>
-Florian Plaza Oñate <florian dot plaza at jouy dot inra dot  fr>
+Joel Poudroux
+Florian Plaza OÃ±ate <florian dot plaza at jouy dot inra dot  fr>


### PR DESCRIPTION
Hi,
I am Florian Plaza Oñate, one of the authors of xsq-info. The other author, Joel Poudroux, wants to remove his email adress on the Internet.
Could you accept this commit?
Thanks in advance
